### PR TITLE
Handle Opcode::GetEffectName

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -242,6 +242,10 @@ pub fn dispatch(
             return plugin.get_info().category.into();
         }
 
+        OpCode::GetEffectName => {
+            return copy_string(ptr, &plugin.get_info().name, MAX_VENDOR_STR_LEN)
+        }
+
         OpCode::GetVendorName => {
             return copy_string(ptr, &plugin.get_info().vendor, MAX_VENDOR_STR_LEN)
         }


### PR DESCRIPTION
## Issue

Bitwig wasn't getting the VST's name anymore:

<img src="https://i.imgur.com/e5IdDfV.png" width="40%" height="40%">

I assume this is because Bitwig *used to* issue a `GetProductName` opcode to get this, but now it's issuing the `GetEffectName` opcode instead.

## Fix

I simply copy-pasted what we had for `GetProductName` and made it the `GetEffectName` handler too:

<img src="https://i.imgur.com/FtxSEnP.png" width="40%" height="40%">

I know that Carla/JUCE [uses this same opcode to fill in the plugin name](https://github.com/falkTX/Carla/blob/0038f94bf28b4a09ad4df9121e1fab19c02eadfb/source/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp#L600) (they call their equivalent opcode `plugInOpcodeGetPlugInName` [here](https://github.com/falkTX/Carla/blob/0038f94bf28b4a09ad4df9121e1fab19c02eadfb/source/modules/juce_audio_processors/format_types/juce_VSTInterface.h#L126)).

## Question

I couldn't find out what `GetProductName` is *supposed* to be used for, from a quick glance at the Carla code. What should we do there instead?