### PR TITLE
Fix for a use-after-move bug when calling Events::events  more than once

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -482,9 +482,9 @@ impl Events {
 
 /// An iterator over events, returned by `api::Events::events`
 pub struct EventIterator<'a> {
-    current : *const *const Event,
-    end : *const *const Event,
-    _marker : PhantomData<&'a Event>
+    current: *const *const Event,
+    end: *const *const Event,
+    _marker: PhantomData<&'a Event>,
 }
 
 impl<'a> Iterator for EventIterator<'a> {
@@ -493,11 +493,13 @@ impl<'a> Iterator for EventIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current == self.end {
             None
-        }
-        else {
-            let e = unsafe { **self.current }.clone();
-            self.current = unsafe { self.current.offset(1) };
-            Some(e.into())
+        } else {
+            let event = unsafe {
+                let e = (**self.current).clone();
+                self.current = self.current.offset(1);
+                e
+            };
+            Some(event.into())
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -475,7 +475,7 @@ impl Events {
         EventIterator {
             current: ptr,
             end: unsafe { ptr.offset(self.num_events as isize) },
-            _marker : PhantomData
+            _marker: PhantomData
         }
     }
 }


### PR DESCRIPTION
Fixes [this test case](https://gist.github.com/zopu/61919c5eb6354ff0faf7df2959ab351b). 

I added `#[allow(dead_code)]` since it appears that several people are using the `events_raw` method in their own code rather than the iterator. 