### PR TITLE
Parameters should be automatable by default

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -754,7 +754,7 @@ pub trait PluginParameters: Sync {
 
     /// Return whether parameter at `index` can be automated.
     fn can_be_automated(&self, index: i32) -> bool {
-        false
+        true
     }
 
     /// Use String as input for parameter value. Used by host to provide an editable field to


### PR DESCRIPTION
Fixes the issue with parameters not showing up in Bitwig.

In my opinion, there's no reason to have non-automatable parameters exposed to the host. If a plugin needs hidden state, manage it internally.