### PR TITLE
Use AtomicU32 for atomic float values

### DIFF
--- a/src/util/atomic_float.rs
+++ b/src/util/atomic_float.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Simple atomic floating point variable with relaxed ordering.
 ///
@@ -7,24 +7,24 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// is needed.
 pub struct AtomicFloat {
     // TODO: Change atomic to AtomicU32 when stabilized (expected in 1.34).
-    atomic: AtomicUsize,
+    atomic: AtomicU32,
 }
 
 impl AtomicFloat {
     /// New atomic float with initial value `value`.
     pub fn new(value: f32) -> AtomicFloat {
         AtomicFloat {
-            atomic: AtomicUsize::new(value.to_bits() as usize),
+            atomic: AtomicU32::new(value.to_bits()),
         }
     }
 
     /// Get the current value of the atomic float.
     pub fn get(&self) -> f32 {
-        f32::from_bits(self.atomic.load(Ordering::Relaxed) as u32)
+        f32::from_bits(self.atomic.load(Ordering::Relaxed))
     }
 
     /// Set the value of the atomic float to `value`.
     pub fn set(&self, value: f32) {
-        self.atomic.store(value.to_bits() as usize, Ordering::Relaxed)
+        self.atomic.store(value.to_bits(), Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
Original code used `AtomicUsize` (wasting space in 64-bit builds) only because `AtomicU32` wasn't stable at the time. It is now (as of Rust 1.34).