### PR TITLE
removed EventIterator and replaced with impl Trait syntax

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -451,6 +451,7 @@ impl Events {
     /// # }
     /// ```
     #[inline]
+    #[allow(clippy::needless_lifetimes)]
     pub fn events<'a>(&'a self) -> impl Iterator<Item = ::event::Event<'a>> {
         self.events_raw().iter().map(|ptr| unsafe { **ptr }.into())
     }


### PR DESCRIPTION
As discussed on discord, this removes the `EventIterator` struct and replaces it using the `impl Trait` return syntax. 