### PR TITLE
Document and add `update_display` to Host

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -147,7 +147,9 @@ pub enum OpCode {
     /// Get the current directory.
     /// [return]: `FSSpec` on OS X, `char*` otherwise
     GetDirectory,
-    /// No arguments. TODO: Figure out what this does.
+    /// Tell the host that the plugin's parameters have changed, refresh the UI.
+    /// 
+    /// No arguments.
     UpdateDisplay,
     /// Tell the host that if needed, it should record automation data for a control.
     ///
@@ -222,6 +224,9 @@ pub trait Host {
     fn get_block_size(&self) -> isize {
         0
     }
+
+    /// Refresh UI after the plugin's parameters changed.
+    fn update_display(&self) {}
 }
 
 /// All possible errors that can occur when loading a VST plugin.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -965,6 +965,11 @@ impl Host for HostCallback {
     fn get_block_size(&self) -> isize {
         self.callback(self.effect, host::OpCode::GetBlockSize, 0, 0, ptr::null_mut(), 0.0)
     }
+
+    /// Refresh UI after the plugin's parameters changed.
+    fn update_display(&self) {
+        self.callback(self.effect, host::OpCode::UpdateDisplay, 0, 0, ptr::null_mut(), 0.0);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is used when e.g. the user moves a dial in the plugin's editor. The DAW will not notice the change and reflect the new value in its native UI until this message is sent.