### PR TITLE
Make Dispatch trait public

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -30,7 +30,7 @@ pub type HostCallbackProc =
 
 /// Dispatcher function used to process opcodes. Called by host.
 pub type DispatcherProc =
-    fn(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize;
+    unsafe fn(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize;
 
 /// Process function used to process 32 bit floating point samples. Called by host.
 pub type ProcessProc = fn(effect: *mut AEffect, inputs: *const *const f32, outputs: *mut *mut f32, sample_frames: i32);

--- a/src/host.rs
+++ b/src/host.rs
@@ -538,8 +538,8 @@ impl Plugin for PluginInstance {
         }
     }
 
-    fn vendor_specific(&mut self, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize {
-        unsafe { self.dispatch(plugin::OpCode::VendorSpecific, index, value, ptr, opt) }
+    unsafe fn vendor_specific(&mut self, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize {
+        self.dispatch(plugin::OpCode::VendorSpecific, index, value, ptr, opt)
     }
 
     fn can_do(&self, can_do: plugin::CanDo) -> Supported {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -545,7 +545,7 @@ pub trait Plugin {
     fn suspend(&mut self) {}
 
     /// Vendor specific handling.
-    fn vendor_specific(&mut self, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize {
+    unsafe fn vendor_specific(&mut self, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize {
         0
     }
 
@@ -1074,6 +1074,8 @@ mod tests {
     #[test]
     fn host_callbacks() {
         let aeffect = instance();
-        (unsafe { (*aeffect).dispatcher })(aeffect, plugin::OpCode::Initialize.into(), 0, 0, ptr::null_mut(), 0.0);
+        unsafe {
+            ((*aeffect).dispatcher)(aeffect, plugin::OpCode::Initialize.into(), 0, 0, ptr::null_mut(), 0.0);
+        }
     }
 }


### PR DESCRIPTION
This pull request makes the `Dispatch` trait public. I realise that this trait was perhaps not intended to be public, but I found it useful for building a VST host in Rust.

Because this trait calls the underlying VST plugin quite directly, in order to safely expose it I have had to make its provided methods unsafe and push `unsafe { ... }` out to the callers of this trait's provided methods.

I have not made `get_effect` unsafe as it is not inherently unsafe to call this method. Rather, it's unsafe to _implement_ this method. For this reason I have made the `Dispatch` trait an unsafe trait.