### PR TITLE
Allow plug-in to return a custom value in can_do()

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -256,7 +256,7 @@ pub enum Supported {
     Yes,
     Maybe,
     No,
-    Custom(isize)
+    Custom(isize),
 }
 
 impl Supported {
@@ -282,7 +282,7 @@ impl Into<isize> for Supported {
             Yes => 1,
             Maybe => 0,
             No => -1,
-            Custom(i) => i
+            Custom(i) => i,
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -256,6 +256,7 @@ pub enum Supported {
     Yes,
     Maybe,
     No,
+    Custom(isize)
 }
 
 impl Supported {
@@ -281,6 +282,7 @@ impl Into<isize> for Supported {
             Yes => 1,
             Maybe => 0,
             No => -1,
+            Custom(i) => i
         }
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1005,7 +1005,7 @@ mod tests {
 
                 fn new(host: HostCallback) -> TestPlugin {
                     TestPlugin {
-                        host: host
+                        host
                     }
                 }
 


### PR DESCRIPTION
Background: [Cockos Extensions to VST SDK](http://reaper.fm/sdk/vst/vst_ext.php) defines some non-standard behavior controlled via custom `can_do()` return values (other than 1, 0 or -1). I'm currently using this in [ReaLearn](https://github.com/helgoboss/realearn/blob/a7ccda9f5bd27738b40e15f084dfaacc671b299f/src/infrastructure/plugin/realearn_plugin.rs#L119).