### PR TITLE
Implement a few editor related functions for PluginInstance

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -16,6 +16,7 @@ use api::consts::*;
 use api::{self, AEffect, PluginFlags, PluginMain, Supported, TimeInfo};
 use buffer::AudioBuffer;
 use channels::ChannelInfo;
+use editor;
 use interfaces;
 use plugin::{self, Category, Info, Plugin, PluginParameters};
 
@@ -587,6 +588,27 @@ impl Plugin for PluginInstance {
 
     fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
         Arc::clone(&self.params) as Arc<dyn PluginParameters>
+    }
+
+    fn get_editor_rect(&self) -> Option<editor::Rect> {
+        let mut rect: *mut editor::Rect = std::ptr::null_mut();
+        let rect_ptr: *mut *mut editor::Rect = &mut rect;
+
+        self.dispatch(plugin::OpCode::EditorGetRect, 0, 0, rect_ptr as *mut c_void, 0.0);
+
+        if rect != std::ptr::null_mut() {
+            Some(unsafe{ *rect }) // TODO: Who owns rect? Who should free the memory?
+        } else {
+            None
+        }
+    }
+
+    fn open_editor(&self, window_handle: *mut c_void) {
+        self.dispatch(plugin::OpCode::EditorOpen, 0, 0, window_handle, 0.0);
+    }
+
+    fn close_editor(&self) {
+        self.dispatch(plugin::OpCode::EditorClose, 0, 0, ptr::null_mut(), 0.0);
     }
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -16,7 +16,6 @@ use api::consts::*;
 use api::{self, AEffect, PluginFlags, PluginMain, Supported, TimeInfo};
 use buffer::AudioBuffer;
 use channels::ChannelInfo;
-use editor;
 use interfaces;
 use plugin::{self, Category, Info, Plugin, PluginParameters};
 
@@ -588,27 +587,6 @@ impl Plugin for PluginInstance {
 
     fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
         Arc::clone(&self.params) as Arc<dyn PluginParameters>
-    }
-
-    fn get_editor_rect(&self) -> Option<editor::Rect> {
-        let mut rect: *mut editor::Rect = std::ptr::null_mut();
-        let rect_ptr: *mut *mut editor::Rect = &mut rect;
-
-        self.dispatch(plugin::OpCode::EditorGetRect, 0, 0, rect_ptr as *mut c_void, 0.0);
-
-        if rect != std::ptr::null_mut() {
-            Some(unsafe{ *rect }) // TODO: Who owns rect? Who should free the memory?
-        } else {
-            None
-        }
-    }
-
-    fn open_editor(&self, window_handle: *mut c_void) {
-        self.dispatch(plugin::OpCode::EditorOpen, 0, 0, window_handle, 0.0);
-    }
-
-    fn close_editor(&self) {
-        self.dispatch(plugin::OpCode::EditorClose, 0, 0, ptr::null_mut(), 0.0);
     }
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -300,12 +300,12 @@ impl Drop for PluginInstance {
 }
 
 /// The editor of an externally loaded VST plugin.
-pub struct PluginEditor {
+struct EditorInstance {
     params: Arc<PluginParametersInstance>,
     is_open: bool,
 }
 
-impl PluginEditor {
+impl EditorInstance {
     fn get_rect(&self) -> Option<Rect> {
         let mut rect: *mut Rect = std::ptr::null_mut();
         let rect_ptr: *mut *mut Rect = &mut rect;
@@ -319,7 +319,7 @@ impl PluginEditor {
     }
 }
 
-impl Editor for PluginEditor {
+impl Editor for EditorInstance {
     fn size(&self) -> (i32, i32) {
         // Assuming coordinate origins from top-left
         match self.get_rect() {
@@ -665,7 +665,7 @@ impl Plugin for PluginInstance {
         }
 
         self.is_editor_active = true;
-        Some(Box::new(PluginEditor{ params: self.params.clone(), is_open: false }))
+        Some(Box::new(EditorInstance{ params: self.params.clone(), is_open: false }))
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -9,7 +9,7 @@ use api::consts::VST_MAGIC;
 use api::{AEffect, HostCallbackProc, Supported, TimeInfo};
 use buffer::AudioBuffer;
 use channels::ChannelInfo;
-use editor::{Editor, Rect};
+use editor::Editor;
 use host::{self, Host};
 
 /// Plugin type. Generally either Effect or Synth.
@@ -698,20 +698,6 @@ pub trait Plugin {
     fn get_editor(&mut self) -> Option<Box<dyn Editor>> {
         None
     }
-
-    /// Asks the plugin about the dimensions of its editor
-    fn get_editor_rect(&self) -> Option<Rect> {
-        None
-    }
-
-    /// Asks the plugin to open the editor in the provided window handle.
-    ///
-    /// The window handle must be a pointer to a window object native to the platform (e.g. HWND on
-    /// Windows, or NSView* on macOS).
-    fn open_editor(&self, window_handle: *mut c_void) {}
-
-    /// Asks the plugin to close the editor.
-    fn close_editor(&self) {}
 }
 
 /// Parameter object shared between the UI and processing threads.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -9,7 +9,7 @@ use api::consts::VST_MAGIC;
 use api::{AEffect, HostCallbackProc, Supported, TimeInfo};
 use buffer::AudioBuffer;
 use channels::ChannelInfo;
-use editor::Editor;
+use editor::{Editor, Rect};
 use host::{self, Host};
 
 /// Plugin type. Generally either Effect or Synth.
@@ -698,6 +698,20 @@ pub trait Plugin {
     fn get_editor(&mut self) -> Option<Box<dyn Editor>> {
         None
     }
+
+    /// Asks the plugin about the dimensions of its editor
+    fn get_editor_rect(&self) -> Option<Rect> {
+        None
+    }
+
+    /// Asks the plugin to open the editor in the provided window handle.
+    ///
+    /// The window handle must be a pointer to a window object native to the platform (e.g. HWND on
+    /// Windows, or NSView* on macOS).
+    fn open_editor(&self, window_handle: *mut c_void) {}
+
+    /// Asks the plugin to close the editor.
+    fn close_editor(&self) {}
 }
 
 /// Parameter object shared between the UI and processing threads.


### PR DESCRIPTION
This pull request implements a few editor related functions for `PluginInstance`:
- `get_editor_rect()`
- `open_editor()`
- `close_editor()`

I'm writing a VST plugin host GUI application using `vst-rs` and find these functions useful.