### PR TITLE
Introduce zero-valued EventType to enable zero-initialization of Event

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -461,6 +461,9 @@ impl Events {
 #[repr(i32)]
 #[derive(Copy, Clone, Debug)]
 pub enum EventType {
+    /// Value used for uninitialized placeholder events.
+    _Placeholder = 0,
+
     /// Midi event. See `api::MidiEvent`.
     Midi = 1,
 


### PR DESCRIPTION
Introduce zero-valued EventType to enable zero-initialization of Event.

Fixes https://github.com/RustAudio/vst-rs/issues/131
