### PR TITLE
Default value for AtomicFloat

### DIFF
--- a/src/util/atomic_float.rs
+++ b/src/util/atomic_float.rs
@@ -27,3 +27,9 @@ impl AtomicFloat {
         self.atomic.store(value.to_bits(), Ordering::Relaxed)
     }
 }
+
+impl Default for AtomicFloat {
+    fn default() -> Self {
+        AtomicFloat::new(0.0)
+    }
+}


### PR DESCRIPTION
Default value for AtomicFloat.

Fixes https://github.com/RustAudio/vst-rs/issues/137