### PR TITLE
Require Plugin to be Send, avoid concurrent &mut

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,9 +1,11 @@
 //! Structures and types for interfacing with the VST 2.4 API.
 
 use std::os::raw::c_void;
+use std::sync::Arc;
 
 use self::consts::*;
-use plugin::Plugin;
+use editor::Editor;
+use plugin::{Info, Plugin, PluginParameters};
 
 /// Constant values
 #[allow(missing_docs)] // For obvious constants
@@ -130,21 +132,34 @@ pub struct AEffect {
 
 impl AEffect {
     /// Return handle to Plugin object. Only works for plugins created using this library.
+    /// Caller is responsible for not calling this function concurrently.
     // Supresses warning about returning a reference to a box
     #[allow(clippy::borrowed_box)]
-    pub unsafe fn get_plugin(&mut self) -> &mut Box<dyn Plugin> {
+    pub unsafe fn get_plugin(&self) -> &mut Box<dyn Plugin> {
         //FIXME: find a way to do this without resorting to transmuting via a box
         &mut *(self.object as *mut Box<dyn Plugin>)
+    }
+
+    /// Return handle to Info object. Only works for plugins created using this library.
+    pub unsafe fn get_info(&self) -> &Info {
+        &(*(self.user as *mut super::PluginCache)).info
+    }
+
+    /// Return handle to PluginParameters object. Only works for plugins created using this library.
+    pub unsafe fn get_params(&self) -> &Arc<dyn PluginParameters> {
+        &(*(self.user as *mut super::PluginCache)).params
+    }
+
+    /// Return handle to Editor object. Only works for plugins created using this library.
+    /// Caller is responsible for not calling this function concurrently.
+    pub unsafe fn get_editor(&self) -> &mut Option<Box<dyn Editor>> {
+        &mut (*(self.user as *mut super::PluginCache)).editor
     }
 
     /// Drop the Plugin object. Only works for plugins created using this library.
     pub unsafe fn drop_plugin(&mut self) {
         drop(Box::from_raw(self.object as *mut Box<dyn Plugin>));
         drop(Box::from_raw(self.user as *mut super::PluginCache));
-    }
-
-    pub(crate) unsafe fn get_cache(&mut self) -> &mut super::PluginCache {
-        &mut *(self.user as *mut _)
     }
 }
 
@@ -621,6 +636,8 @@ pub struct SysExEvent {
     /// Reserved for future use. Should be 0.
     pub _reserved2: isize,
 }
+
+unsafe impl Send for SysExEvent {}
 
 #[repr(C)]
 #[derive(Clone, Default, Copy)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -289,6 +289,7 @@ struct PluginParametersInstance {
     effect: UnsafeCell<*mut AEffect>,
 }
 
+unsafe impl Send for PluginParametersInstance {}
 unsafe impl Sync for PluginParametersInstance {}
 
 impl Drop for PluginInstance {

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -30,8 +30,7 @@ pub fn process_replacing(
 ) {
     // Handle to the VST
     let plugin = unsafe { (*effect).get_plugin() };
-    let cache = unsafe { (*effect).get_cache() };
-    let info = &mut cache.info;
+    let info = unsafe { (*effect).get_info() };
     let (input_count, output_count) = (info.inputs as usize, info.outputs as usize);
     let mut buffer =
         unsafe { AudioBuffer::from_raw(input_count, output_count, raw_inputs, raw_outputs, samples as usize) };
@@ -46,8 +45,7 @@ pub fn process_replacing_f64(
     samples: i32,
 ) {
     let plugin = unsafe { (*effect).get_plugin() };
-    let cache = unsafe { (*effect).get_cache() };
-    let info = &mut cache.info;
+    let info = unsafe { (*effect).get_info() };
     let (input_count, output_count) = (info.inputs as usize, info.outputs as usize);
     let mut buffer =
         unsafe { AudioBuffer::from_raw(input_count, output_count, raw_inputs, raw_outputs, samples as usize) };
@@ -56,12 +54,12 @@ pub fn process_replacing_f64(
 
 /// VST2.4 set parameter function.
 pub fn set_parameter(effect: *mut AEffect, index: i32, value: f32) {
-    unsafe { (*effect).get_cache() }.params.set_parameter(index, value);
+    unsafe { (*effect).get_params() }.set_parameter(index, value);
 }
 
 /// VST2.4 get parameter function.
 pub fn get_parameter(effect: *mut AEffect, index: i32) -> f32 {
-    unsafe { (*effect).get_cache() }.params.get_parameter(index)
+    unsafe { (*effect).get_params() }.get_parameter(index)
 }
 
 /// Copy a string into a destination buffer.
@@ -86,13 +84,14 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
 
     // Convert passed in opcode to enum
     let opcode = OpCode::from(opcode);
-    // Plugin handle
-    let plugin = unsafe { (*effect).get_plugin() };
-    let cache = unsafe { (*effect).get_cache() };
-    let params = &cache.params;
+    // Only query plugin or editor when needed to avoid creating multiple
+    // concurrent mutable references to the same object.
+    let get_plugin = || unsafe { (*effect).get_plugin() };
+    let get_editor = || unsafe { (*effect).get_editor() };
+    let params = unsafe { (*effect).get_params() };
 
     match opcode {
-        OpCode::Initialize => plugin.init(),
+        OpCode::Initialize => get_plugin().init(),
         OpCode::Shutdown => unsafe {
             (*effect).drop_plugin();
             drop(Box::from_raw(effect))
@@ -110,18 +109,18 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         OpCode::GetParameterDisplay => return copy_string(ptr, &params.get_parameter_text(index), MAX_PARAM_STR_LEN),
         OpCode::GetParameterName => return copy_string(ptr, &params.get_parameter_name(index), MAX_PARAM_STR_LEN),
 
-        OpCode::SetSampleRate => plugin.set_sample_rate(opt),
-        OpCode::SetBlockSize => plugin.set_block_size(value as i64),
+        OpCode::SetSampleRate => get_plugin().set_sample_rate(opt),
+        OpCode::SetBlockSize => get_plugin().set_block_size(value as i64),
         OpCode::StateChanged => {
             if value == 1 {
-                plugin.resume();
+                get_plugin().resume();
             } else {
-                plugin.suspend();
+                get_plugin().suspend();
             }
         }
 
         OpCode::EditorGetRect => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 let size = editor.size();
                 let pos = editor.position();
 
@@ -140,7 +139,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
             }
         }
         OpCode::EditorOpen => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 // `ptr` is a window handle to the parent window.
                 // See the documentation for `Editor::open` for details.
                 if editor.open(ptr) {
@@ -149,13 +148,13 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
             }
         }
         OpCode::EditorClose => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 editor.close();
             }
         }
 
         OpCode::EditorIdle => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 editor.idle();
             }
         }
@@ -188,7 +187,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         }
 
         OpCode::ProcessEvents => {
-            plugin.process_events(unsafe { &*(ptr as *const api::Events) });
+            get_plugin().process_events(unsafe { &*(ptr as *const api::Events) });
         }
         OpCode::CanBeAutomated => return params.can_be_automated(index) as isize,
         OpCode::StringToParameter => return params.string_to_parameter(index, read_string(ptr)) as isize,
@@ -196,40 +195,40 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         OpCode::GetPresetName => return copy_string(ptr, &params.get_preset_name(index), MAX_PRESET_NAME_LEN),
 
         OpCode::GetInputInfo => {
-            if index >= 0 && index < plugin.get_info().inputs {
+            if index >= 0 && index < get_plugin().get_info().inputs {
                 unsafe {
                     let ptr = ptr as *mut api::ChannelProperties;
-                    *ptr = plugin.get_input_info(index).into();
+                    *ptr = get_plugin().get_input_info(index).into();
                 }
             }
         }
         OpCode::GetOutputInfo => {
-            if index >= 0 && index < plugin.get_info().outputs {
+            if index >= 0 && index < get_plugin().get_info().outputs {
                 unsafe {
                     let ptr = ptr as *mut api::ChannelProperties;
-                    *ptr = plugin.get_output_info(index).into();
+                    *ptr = get_plugin().get_output_info(index).into();
                 }
             }
         }
         OpCode::GetCategory => {
-            return plugin.get_info().category.into();
+            return get_plugin().get_info().category.into();
         }
 
-        OpCode::GetEffectName => return copy_string(ptr, &plugin.get_info().name, MAX_VENDOR_STR_LEN),
+        OpCode::GetEffectName => return copy_string(ptr, &get_plugin().get_info().name, MAX_VENDOR_STR_LEN),
 
-        OpCode::GetVendorName => return copy_string(ptr, &plugin.get_info().vendor, MAX_VENDOR_STR_LEN),
-        OpCode::GetProductName => return copy_string(ptr, &plugin.get_info().name, MAX_PRODUCT_STR_LEN),
-        OpCode::GetVendorVersion => return plugin.get_info().version as isize,
-        OpCode::VendorSpecific => return plugin.vendor_specific(index, value, ptr, opt),
+        OpCode::GetVendorName => return copy_string(ptr, &get_plugin().get_info().vendor, MAX_VENDOR_STR_LEN),
+        OpCode::GetProductName => return copy_string(ptr, &get_plugin().get_info().name, MAX_PRODUCT_STR_LEN),
+        OpCode::GetVendorVersion => return get_plugin().get_info().version as isize,
+        OpCode::VendorSpecific => return get_plugin().vendor_specific(index, value, ptr, opt),
         OpCode::CanDo => {
             let can_do = CanDo::from_str(&read_string(ptr));
-            return plugin.can_do(can_do).into();
+            return get_plugin().can_do(can_do).into();
         }
         OpCode::GetTailSize => {
-            if plugin.get_tail_size() == 0 {
+            if get_plugin().get_tail_size() == 0 {
                 return 1;
             } else {
-                return plugin.get_tail_size();
+                return get_plugin().get_tail_size();
             }
         }
 
@@ -237,7 +236,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
         OpCode::GetApiVersion => return 2400,
 
         OpCode::EditorKeyDown => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 editor.key_down(KeyCode {
                     character: index as u8 as char,
                     key: Key::from(value),
@@ -246,7 +245,7 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
             }
         }
         OpCode::EditorKeyUp => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 editor.key_up(KeyCode {
                     character: index as u8 as char,
                     key: Key::from(value),
@@ -255,16 +254,16 @@ pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr
             }
         }
         OpCode::EditorSetKnobMode => {
-            if let Some(ref mut editor) = cache.editor {
+            if let Some(ref mut editor) = get_editor() {
                 editor.set_knob_mode(KnobMode::from(value));
             }
         }
 
-        OpCode::StartProcess => plugin.start_process(),
-        OpCode::StopProcess => plugin.stop_process(),
+        OpCode::StartProcess => get_plugin().start_process(),
+        OpCode::StopProcess => get_plugin().stop_process(),
 
-        OpCode::GetNumMidiInputs => return unsafe { (*effect).get_cache() }.info.midi_inputs as isize,
-        OpCode::GetNumMidiOutputs => return unsafe { (*effect).get_cache() }.info.midi_outputs as isize,
+        OpCode::GetNumMidiInputs => return unsafe { (*effect).get_info() }.midi_inputs as isize,
+        OpCode::GetNumMidiOutputs => return unsafe { (*effect).get_info() }.midi_outputs as isize,
 
         _ => {
             debug!("Unimplemented opcode ({:?})", opcode);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -470,7 +470,7 @@ impl Into<String> for CanDo {
 /// traits: The `Plugin` trait containing setup and processing methods, and
 /// the `PluginParameters` trait containing methods for parameter access.
 #[allow(unused_variables)]
-pub trait Plugin {
+pub trait Plugin : Send {
     /// This method must return an `Info` struct.
     fn get_info(&self) -> Info;
 


### PR DESCRIPTION
**Breaking change**: Require `Plugin` to be `Send`, since its methods can be called from different threads at different times.

Restructure dispatch code to avoid obtaining concurrent `&mut` references to the `Plugin` or `Editor`.

Fixes https://github.com/RustAudio/vst-rs/issues/132