### PR TITLE
Mark function pointers in AEffect as extern, since these are called directly from C code.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -26,24 +26,25 @@ pub type PluginMain = fn(callback: HostCallbackProc) -> *mut AEffect;
 /// Host callback function passed to plugin.
 /// Can be used to query host information from plugin side.
 pub type HostCallbackProc =
-    fn(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize;
+    extern "C" fn(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize;
 
 /// Dispatcher function used to process opcodes. Called by host.
 pub type DispatcherProc =
-    fn(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize;
+    extern "C" fn(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize;
 
 /// Process function used to process 32 bit floating point samples. Called by host.
-pub type ProcessProc = fn(effect: *mut AEffect, inputs: *const *const f32, outputs: *mut *mut f32, sample_frames: i32);
+pub type ProcessProc =
+    extern "C" fn(effect: *mut AEffect, inputs: *const *const f32, outputs: *mut *mut f32, sample_frames: i32);
 
 /// Process function used to process 64 bit floating point samples. Called by host.
 pub type ProcessProcF64 =
-    fn(effect: *mut AEffect, inputs: *const *const f64, outputs: *mut *mut f64, sample_frames: i32);
+    extern "C" fn(effect: *mut AEffect, inputs: *const *const f64, outputs: *mut *mut f64, sample_frames: i32);
 
 /// Callback function used to set parameter values. Called by host.
-pub type SetParameterProc = fn(effect: *mut AEffect, index: i32, parameter: f32);
+pub type SetParameterProc = extern "C" fn(effect: *mut AEffect, index: i32, parameter: f32);
 
 /// Callback function used to get parameter values. Called by host.
-pub type GetParameterProc = fn(effect: *mut AEffect, index: i32) -> f32;
+pub type GetParameterProc = extern "C" fn(effect: *mut AEffect, index: i32) -> f32;
 
 /// Used with the VST API to pass around plugin information.
 #[allow(non_snake_case)]

--- a/src/host.rs
+++ b/src/host.rs
@@ -884,7 +884,7 @@ impl<T: Float> HostBuffer<T> {
 static mut LOAD_POINTER: *mut c_void = 0 as *mut c_void;
 
 /// Function passed to plugin to handle dispatching host opcodes.
-fn callback_wrapper<T: Host>(
+extern "C" fn callback_wrapper<T: Host>(
     effect: *mut AEffect,
     opcode: i32,
     index: i32,

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -13,7 +13,7 @@ use editor::{Key, KeyCode, KnobMode, Rect};
 use host::Host;
 
 /// Deprecated process function.
-pub fn process_deprecated(
+pub extern "C" fn process_deprecated(
     _effect: *mut AEffect,
     _raw_inputs: *const *const f32,
     _raw_outputs: *mut *mut f32,
@@ -22,7 +22,7 @@ pub fn process_deprecated(
 }
 
 /// VST2.4 replacing function.
-pub fn process_replacing(
+pub extern "C" fn process_replacing(
     effect: *mut AEffect,
     raw_inputs: *const *const f32,
     raw_outputs: *mut *mut f32,
@@ -39,7 +39,7 @@ pub fn process_replacing(
 }
 
 /// VST2.4 replacing function with `f64` values.
-pub fn process_replacing_f64(
+pub extern "C" fn process_replacing_f64(
     effect: *mut AEffect,
     raw_inputs: *const *const f64,
     raw_outputs: *mut *mut f64,
@@ -55,12 +55,12 @@ pub fn process_replacing_f64(
 }
 
 /// VST2.4 set parameter function.
-pub fn set_parameter(effect: *mut AEffect, index: i32, value: f32) {
+pub extern "C" fn set_parameter(effect: *mut AEffect, index: i32, value: f32) {
     unsafe { (*effect).get_cache() }.params.set_parameter(index, value);
 }
 
 /// VST2.4 get parameter function.
-pub fn get_parameter(effect: *mut AEffect, index: i32) -> f32 {
+pub extern "C" fn get_parameter(effect: *mut AEffect, index: i32) -> f32 {
     unsafe { (*effect).get_cache() }.params.get_parameter(index)
 }
 
@@ -81,7 +81,14 @@ fn copy_string(dst: *mut c_void, src: &str, max: usize) -> isize {
 }
 
 /// VST2.4 dispatch function. This function handles dispatching all opcodes to the VST plugin.
-pub fn dispatch(effect: *mut AEffect, opcode: i32, index: i32, value: isize, ptr: *mut c_void, opt: f32) -> isize {
+pub extern "C" fn dispatch(
+    effect: *mut AEffect,
+    opcode: i32,
+    index: i32,
+    value: isize,
+    ptr: *mut c_void,
+    opt: f32,
+) -> isize {
     use plugin::{CanDo, OpCode};
 
     // Convert passed in opcode to enum

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,7 @@ mod tests {
 
     plugin_main!(TestPlugin);
 
-    fn pass_callback(
+    extern "C" fn pass_callback(
         _effect: *mut AEffect,
         _opcode: i32,
         _index: i32,
@@ -329,7 +329,7 @@ mod tests {
         1
     }
 
-    fn fail_callback(
+    extern "C" fn fail_callback(
         _effect: *mut AEffect,
         _opcode: i32,
         _index: i32,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1021,13 +1021,14 @@ mod tests {
 
             #[allow(dead_code)]
             fn instance() -> *mut AEffect {
-                fn host_callback(_effect: *mut AEffect,
-                                 opcode: i32,
-                                 index: i32,
-                                 _value: isize,
-                                 _ptr: *mut c_void,
-                                 opt: f32)
-                                 -> isize {
+                extern "C" fn host_callback(
+                    _effect: *mut AEffect,
+                    opcode: i32,
+                    index: i32,
+                    _value: isize,
+                    _ptr: *mut c_void,
+                    opt: f32,
+                ) -> isize {
                     let opcode = OpCode::from(opcode);
                     match opcode {
                         OpCode::Automate => {


### PR DESCRIPTION
Mark function pointers in AEffect as extern, since these are called directly from C code.

Fixes warning about `HostCallbackProc` being passed as parameter to an `extern` function.