### PR TITLE
Key character fix

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -93,7 +93,8 @@ impl_clike!(KnobMode);
 #[repr(usize)]
 #[derive(Debug, Copy, Clone)]
 pub enum Key {
-    Back = 1,
+    None = 0,
+    Back,
     Tab,
     Clear,
     Return,

--- a/src/host.rs
+++ b/src/host.rs
@@ -192,6 +192,12 @@ pub trait Host {
     /// Automate a parameter; the value has been changed.
     fn automate(&self, index: i32, value: f32) {}
 
+    /// Signal that automation of a parameter started (the knob has been touched / mouse button down).
+    fn begin_edit(&self, index: i32) { }
+
+    /// Signal that automation of a parameter ended (the knob is no longer been touched / mouse button up).
+    fn end_edit(&self, index: i32) { }
+
     /// Get the plugin ID of the currently loading plugin.
     ///
     /// This is only useful for shell plugins where this value will change the plugin returned.

--- a/src/host.rs
+++ b/src/host.rs
@@ -193,10 +193,10 @@ pub trait Host {
     fn automate(&self, index: i32, value: f32) {}
 
     /// Signal that automation of a parameter started (the knob has been touched / mouse button down).
-    fn begin_edit(&self, index: i32) { }
+    fn begin_edit(&self, index: i32) {}
 
     /// Signal that automation of a parameter ended (the knob is no longer been touched / mouse button up).
-    fn end_edit(&self, index: i32) { }
+    fn end_edit(&self, index: i32) {}
 
     /// Get the plugin ID of the currently loading plugin.
     ///

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -295,6 +295,8 @@ pub fn host_dispatch(
     match OpCode::from(opcode) {
         OpCode::Version => return 2400,
         OpCode::Automate => host.automate(index, opt),
+        OpCode::BeginEdit => host.begin_edit(index),
+        OpCode::EndEdit => host.end_edit(index),
 
         OpCode::Idle => host.idle(),
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1049,7 +1049,7 @@ mod tests {
                     match opcode {
                         OpCode::BeginEdit => {
                             assert_eq!(index, 123);
-                            true
+                            0
                         },
                         OpCode::Automate => {
                             assert_eq!(index, 123);
@@ -1058,7 +1058,7 @@ mod tests {
                         },
                         OpCode::EndEdit => {
                             assert_eq!(index, 123);
-                            true
+                            0
                         },
                         OpCode::Version => 2400,
                         OpCode::CurrentId => 9876,


### PR DESCRIPTION
The plugin seems to crash if I type a non special key like 'a' in a host like Ardour.
The problem is, that the key "0" is not mapped to any Key enum.

The correct fix would be to support `keyboard_types` crate (like baseview), but that's maybe for later.