### PR TITLE
Don't require Plugin to impl Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,11 @@ vst = { git = "https://github.com/rustaudio/vst-rs" }
 ```
 
 ## Usage
-To create a plugin, simply create a type which implements `plugin::Plugin` and
-`std::default::Default`. Then call the macro `plugin_main!`, which will export
-the necessary functions and handle dealing with the rest of the API.
+To create a plugin, simply create a type which implements the `Plugin` trait. Then call the `plugin_main` macro, which will export the necessary functions and handle dealing with the rest of the API.
 
 ## Example Plugin
-A simple plugin that bears no functionality. The provided Cargo.toml has a
-crate-type directive which builds a dynamic library, usable by any VST host.
+A simple plugin that bears no functionality. The provided `Cargo.toml` has a
+`crate-type` directive which builds a dynamic library, usable by any VST host.
 
 `src/lib.rs`
 
@@ -61,7 +59,6 @@ impl Plugin for BasicPlugin {
         Info {
             name: "Basic Plugin".to_string(),
             unique_id: 1357, // Used by hosts to differentiate between plugins.
-
             ..Default::default()
         }
     }

--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ crate-type directive which builds a dynamic library, usable by any VST host.
 #[macro_use]
 extern crate vst;
 
-use vst::plugin::{Info, Plugin};
+use vst::plugin::{HostCallback, Info, Plugin};
 
-#[derive(Default)]
 struct BasicPlugin;
 
 impl Plugin for BasicPlugin {
+    fn new(_host: HostCallback) -> Self {
+        BasicPlugin
+    }
+
     fn get_info(&self) -> Info {
         Info {
             name: "Basic Plugin".to_string(),

--- a/examples/dimension_expander.rs
+++ b/examples/dimension_expander.rs
@@ -5,7 +5,7 @@ extern crate vst;
 extern crate time;
 
 use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, Info, Plugin, PluginParameters};
+use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
 use vst::util::AtomicFloat;
 
 use std::collections::VecDeque;
@@ -42,12 +42,6 @@ struct DimensionExpander {
 struct DimensionExpanderParameters {
     dry_wet: AtomicFloat,
     size: AtomicFloat,
-}
-
-impl Default for DimensionExpander {
-    fn default() -> DimensionExpander {
-        DimensionExpander::new(0.12, 0.66)
-    }
 }
 
 impl DimensionExpander {
@@ -107,6 +101,10 @@ impl DimensionExpander {
 }
 
 impl Plugin for DimensionExpander {
+    fn new(_host: HostCallback) -> Self {
+        DimensionExpander::new(0.12, 0.66)
+    }
+
     fn get_info(&self) -> Info {
         Info {
             name: "Dimension Expander".to_string(),

--- a/examples/fwd_midi.rs
+++ b/examples/fwd_midi.rs
@@ -24,9 +24,10 @@ impl MyPlugin {
 
 impl Plugin for MyPlugin {
     fn new(host: HostCallback) -> Self {
-        let mut p = MyPlugin::default();
-        p.host = host;
-        p
+        MyPlugin {
+            host,
+            ..Default::default()
+        }
     }
 
     fn get_info(&self) -> Info {

--- a/examples/gain_effect.rs
+++ b/examples/gain_effect.rs
@@ -5,7 +5,7 @@ extern crate vst;
 extern crate time;
 
 use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, Info, Plugin, PluginParameters};
+use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
 use vst::util::AtomicFloat;
 
 use std::sync::Arc;
@@ -33,18 +33,6 @@ struct GainEffectParameters {
     amplitude: AtomicFloat,
 }
 
-// All plugins using the `vst` crate will either need to implement the `Default`
-// trait, or derive from it.  By implementing the trait, we can set a default value.
-// Note that controls will always return a value from 0 - 1.  Setting a default to
-// 0.5 means it's halfway up.
-impl Default for GainEffect {
-    fn default() -> GainEffect {
-        GainEffect {
-            params: Arc::new(GainEffectParameters::default()),
-        }
-    }
-}
-
 impl Default for GainEffectParameters {
     fn default() -> GainEffectParameters {
         GainEffectParameters {
@@ -56,6 +44,14 @@ impl Default for GainEffectParameters {
 // All plugins using `vst` also need to implement the `Plugin` trait.  Here, we
 // define functions that give necessary info to our host.
 impl Plugin for GainEffect {
+    fn new(_host: HostCallback) -> Self {
+        // Note that controls will always return a value from 0 - 1.
+        // Setting a default to 0.5 means it's halfway up.
+        GainEffect {
+            params: Arc::new(GainEffectParameters::default()),
+        }
+    }
+
     fn get_info(&self) -> Info {
         Info {
             name: "Gain Effect in Rust".to_string(),

--- a/examples/ladder_filter.rs
+++ b/examples/ladder_filter.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, Info, Plugin, PluginParameters};
+use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
 use vst::util::AtomicFloat;
 
 // this is a 4-pole filter with resonance, which is why there's 4 states and vouts
@@ -194,16 +194,14 @@ impl PluginParameters for LadderParameters {
         }
     }
 }
-impl Default for LadderFilter {
-    fn default() -> LadderFilter {
+impl Plugin for LadderFilter {
+    fn new(_host: HostCallback) -> Self {
         LadderFilter {
             vout: [0f32; 4],
             s: [0f32; 4],
             params: Arc::new(LadderParameters::default()),
         }
     }
-}
-impl Plugin for LadderFilter {
     fn set_sample_rate(&mut self, rate: f32) {
         self.params.sample_rate.set(rate);
     }

--- a/examples/sine_synth.rs
+++ b/examples/sine_synth.rs
@@ -6,7 +6,7 @@ extern crate vst;
 use vst::api::{Events, Supported};
 use vst::buffer::AudioBuffer;
 use vst::event::Event;
-use vst::plugin::{CanDo, Category, Info, Plugin};
+use vst::plugin::{CanDo, Category, HostCallback, Info, Plugin};
 
 use std::f64::consts::PI;
 
@@ -65,8 +65,8 @@ impl SineSynth {
 
 pub const TAU: f64 = PI * 2.0;
 
-impl Default for SineSynth {
-    fn default() -> SineSynth {
+impl Plugin for SineSynth {
+    fn new(_host: HostCallback) -> Self {
         SineSynth {
             sample_rate: 44100.0,
             note_duration: 0.0,
@@ -74,9 +74,7 @@ impl Default for SineSynth {
             note: None,
         }
     }
-}
 
-impl Plugin for SineSynth {
     fn get_info(&self) -> Info {
         Info {
             name: "SineSynth".to_string(),

--- a/examples/transfer_and_smooth.rs
+++ b/examples/transfer_and_smooth.rs
@@ -21,7 +21,6 @@ const TWO_PI: f32 = 2.0 * f32::consts::PI;
 
 // 1. Define a struct to hold parameters. Put a ParameterTransfer inside it,
 // plus optionally a HostCallback.
-#[derive(Default)]
 struct MyPluginParameters {
     #[allow(dead_code)]
     host: HostCallback,
@@ -29,7 +28,6 @@ struct MyPluginParameters {
 }
 
 // 2. Put an Arc reference to your parameter struct in your main Plugin struct.
-#[derive(Default)]
 struct MyPlugin {
     params: Arc<MyPluginParameters>,
     states: Vec<Smoothed>,

--- a/src/api.rs
+++ b/src/api.rs
@@ -455,6 +455,8 @@ impl Events {
     /// # use vst::event::{Event, MidiEvent};
     /// # struct ExamplePlugin { host: HostCallback, send_buf: SendEventBuffer }
     /// # impl Plugin for ExamplePlugin {
+    /// #     fn new(host: HostCallback) -> Self { Self { host, send_buf: Default::default() } }
+    /// #
     /// #     fn get_info(&self) -> Info { Default::default() }
     /// #
     /// fn process_events(&mut self, events: &api::Events) {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -419,6 +419,8 @@ impl SendEventBuffer {
     /// # use vst::event::*;
     /// # struct ExamplePlugin { host: HostCallback, send_buffer: SendEventBuffer }
     /// # impl Plugin for ExamplePlugin {
+    /// #     fn new(host: HostCallback) -> Self { Self { host, send_buffer: Default::default() } }
+    /// #
     /// #     fn get_info(&self) -> Info { Default::default() }
     /// #
     /// fn process(&mut self, buffer: &mut AudioBuffer<f32>){

--- a/src/host.rs
+++ b/src/host.rs
@@ -18,7 +18,7 @@ use buffer::AudioBuffer;
 use channels::ChannelInfo;
 use editor::{Editor, Rect};
 use interfaces;
-use plugin::{self, Category, Info, Plugin, PluginParameters};
+use plugin::{self, Category, HostCallback, Info, Plugin, PluginParameters};
 
 #[repr(usize)]
 #[derive(Clone, Copy, Debug)]
@@ -564,6 +564,11 @@ impl Dispatch for PluginParametersInstance {
 impl Plugin for PluginInstance {
     fn get_info(&self) -> plugin::Info {
         self.info.clone()
+    }
+
+    fn new(_host: HostCallback) -> Self {
+        // Plugin::new is only called on client side and PluginInstance is only used on host side
+        unreachable!()
     }
 
     fn init(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,15 @@
 //! #[macro_use]
 //! extern crate vst;
 //!
-//! use vst::plugin::{Info, Plugin};
+//! use vst::plugin::{HostCallback, Info, Plugin};
 //!
-//! #[derive(Default)]
 //! struct BasicPlugin;
 //!
 //! impl Plugin for BasicPlugin {
+//!     fn new(_host: HostCallback) -> Self {
+//!         BasicPlugin
+//!     }
+//!
 //!     fn get_info(&self) -> Info {
 //!         Info {
 //!             name: "Basic Plugin".to_string(),
@@ -159,8 +162,7 @@ use plugin::{HostCallback, Plugin};
 
 /// Exports the necessary symbols for the plugin to be used by a VST host.
 ///
-/// This macro takes a type which must implement the traits `plugin::Plugin` and
-/// `std::default::Default`.
+/// This macro takes a type which must implement the `Plugin` trait.
 #[macro_export]
 macro_rules! plugin_main {
     ($t:ty) => {
@@ -187,7 +189,7 @@ macro_rules! plugin_main {
 
 /// Initializes a VST plugin and returns a raw pointer to an AEffect struct.
 #[doc(hidden)]
-pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
+pub fn main<T: Plugin>(callback: HostCallbackProc) -> *mut AEffect {
     // Initialize as much of the AEffect as we can before creating the plugin.
     // In particular, initialize all the function pointers, since initializing
     // these to zero is undefined behavior.
@@ -292,12 +294,15 @@ mod tests {
     use api::consts::VST_MAGIC;
     use api::AEffect;
     use interfaces;
-    use plugin::{Info, Plugin};
+    use plugin::{HostCallback, Info, Plugin};
 
-    #[derive(Default)]
     struct TestPlugin;
 
     impl Plugin for TestPlugin {
+        fn new(_host: HostCallback) -> Self {
+            TestPlugin
+        }
+
         fn get_info(&self) -> Info {
             Info {
                 name: "Test Plugin".to_string(),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -454,8 +454,8 @@ impl Into<String> for CanDo {
 
 /// Must be implemented by all VST plugins.
 ///
-/// All methods except `get_info` provide a default implementation which does nothing and can be
-/// safely overridden.
+/// All methods except `new` and `get_info` provide a default implementation
+/// which does nothing and can be safely overridden.
 ///
 /// At any time, a plugin is in one of two states: *suspended* or *resumed*.
 /// While a plugin is in the *suspended* state, various processing parameters,
@@ -789,35 +789,8 @@ impl PluginParameters for DummyPluginParameters {}
 ///
 /// # Panics
 ///
-/// All methods in this struct will panic if the plugin has not yet been initialized. In practice,
-/// this can only occur if the plugin queries the host for information when `Default::default()` is
-/// called.
-///
-/// ```should_panic
-/// # use vst::plugin::{Info, Plugin, HostCallback};
-/// struct ExamplePlugin;
-///
-/// impl Default for ExamplePlugin {
-///     fn default() -> ExamplePlugin {
-///         // Will panic, don't do this. If needed, you can query
-///         // the host during initialization in `Plugin::new()`
-///         let host: HostCallback = Default::default();
-///         let version = host.vst_version();
-///
-///         // ...
-/// #         ExamplePlugin
-///     }
-/// }
-/// #
-/// # impl Plugin for ExamplePlugin {
-/// #     fn new(_host: HostCallback) -> Self {
-/// #         Default::default()
-/// #     }
-/// #
-/// #     fn get_info(&self) -> Info { Default::default() }
-/// # }
-/// # fn main() { let plugin: ExamplePlugin = Default::default(); }
-/// ```
+/// All methods in this struct will panic if the `HostCallback` was constructed using
+/// `Default::default()` rather than being set to the value passed to `Plugin::new`.
 #[derive(Copy, Clone)]
 pub struct HostCallback {
     callback: Option<HostCallbackProc>,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -487,7 +487,6 @@ pub trait Plugin: Send {
     /// # use vst::plugin::{Plugin, Info};
     /// use vst::plugin::HostCallback;
     ///
-    /// # #[derive(Default)]
     /// struct ExamplePlugin {
     ///     host: HostCallback
     /// }
@@ -495,7 +494,7 @@ pub trait Plugin: Send {
     /// impl Plugin for ExamplePlugin {
     ///     fn new(host: HostCallback) -> ExamplePlugin {
     ///         ExamplePlugin {
-    ///             host: host
+    ///             host
     ///         }
     ///     }
     ///
@@ -516,10 +515,7 @@ pub trait Plugin: Send {
     /// ```
     fn new(host: HostCallback) -> Self
     where
-        Self: Sized + Default,
-    {
-        Default::default()
-    }
+        Self: Sized;
 
     /// Called when plugin is fully initialized.
     ///
@@ -566,11 +562,13 @@ pub trait Plugin: Send {
     ///
     /// # Example
     /// ```no_run
-    /// # use vst::plugin::{Info, Plugin};
+    /// # use vst::plugin::{HostCallback, Info, Plugin};
     /// # use vst::buffer::AudioBuffer;
     /// #
     /// # struct ExamplePlugin;
     /// # impl Plugin for ExamplePlugin {
+    /// #     fn new(_host: HostCallback) -> Self { Self }
+    /// #
     /// #     fn get_info(&self) -> Info { Default::default() }
     /// #
     /// // Processor that clips samples above 0.4 or below -0.4:
@@ -607,11 +605,13 @@ pub trait Plugin: Send {
     ///
     /// # Example
     /// ```no_run
-    /// # use vst::plugin::{Info, Plugin};
+    /// # use vst::plugin::{HostCallback, Info, Plugin};
     /// # use vst::buffer::AudioBuffer;
     /// #
     /// # struct ExamplePlugin;
     /// # impl Plugin for ExamplePlugin {
+    /// #     fn new(_host: HostCallback) -> Self { Self }
+    /// #
     /// #     fn get_info(&self) -> Info { Default::default() }
     /// #
     /// // Processor that clips samples above 0.4 or below -0.4:
@@ -800,7 +800,7 @@ impl PluginParameters for DummyPluginParameters {}
 /// impl Default for ExamplePlugin {
 ///     fn default() -> ExamplePlugin {
 ///         // Will panic, don't do this. If needed, you can query
-///         // the host during initialization via Vst::new()
+///         // the host during initialization in `Plugin::new()`
 ///         let host: HostCallback = Default::default();
 ///         let version = host.vst_version();
 ///
@@ -810,6 +810,10 @@ impl PluginParameters for DummyPluginParameters {}
 /// }
 /// #
 /// # impl Plugin for ExamplePlugin {
+/// #     fn new(_host: HostCallback) -> Self {
+/// #         Default::default()
+/// #     }
+/// #
 /// #     fn get_info(&self) -> Info { Default::default() }
 /// # }
 /// # fn main() { let plugin: ExamplePlugin = Default::default(); }


### PR DESCRIPTION
fixes https://github.com/RustAudio/vst-rs/issues/153 by implementing `Plugin::new` for `PluginInstance` by using `unreachable!()`.
It's safe because it's never called anyway. 
(`Plugin::new` is only called on the client side and `PluginInstance` is only used on the host side):
https://github.com/Boscop/rust-vst/blob/0da6e719a26ba67d8302caf26eda1539ee221e81/src/host.rs#L570