### PR TITLE
Rework `SendEventBuffer` to make it useable in `Plugin::process_events`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -458,6 +458,12 @@ impl SendEventBuffer {
         }
     }
 
+    /// Clears the buffer
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        self.set_num_events(0);
+    }
+
     #[inline(always)]
     fn buf_as_api_events(buf: &mut [u8]) -> &mut api::Events {
         #[allow(clippy::cast_ptr_alignment)]


### PR DESCRIPTION
This PR makes `SendEventBuffer::store_events` and `SendEventBuffer::events` public, so that `SendEventBuffer` can be used to feed midi input events from `Plugin::process_events` to `Plugin::process` without allocating memory each frame. 
(See the adjusted `fwd_midi` example, which now doesn't allocate memory each frame for the midi events, but uses `SendEventBuffer` for midi input events.)

I also removed the (now unused) `send_events_to_plugin` method (which was used a while ago when `SendEventBuffer` was a member in `PluginCache` to feed midi events to `Plugin::process_events`).