### PR TITLE
Add prelude for commonly used items

### DIFF
--- a/examples/dimension_expander.rs
+++ b/examples/dimension_expander.rs
@@ -4,13 +4,10 @@
 extern crate vst;
 extern crate time;
 
-use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
-use vst::util::AtomicFloat;
-
 use std::collections::VecDeque;
 use std::f64::consts::PI;
 use std::sync::Arc;
+use vst::prelude::*;
 
 /// Calculate the length in samples for a delay. Size ranges from 0.0 to 1.0.
 fn delay(index: usize, mut size: f32) -> isize {

--- a/examples/dimension_expander.rs
+++ b/examples/dimension_expander.rs
@@ -6,8 +6,8 @@ extern crate vst;
 use std::collections::VecDeque;
 use std::f64::consts::PI;
 use std::sync::Arc;
-use vst::prelude::*;
 use std::time::{SystemTime, UNIX_EPOCH};
+use vst::prelude::*;
 
 /// Calculate the length in samples for a delay. Size ranges from 0.0 to 1.0.
 fn delay(index: usize, mut size: f32) -> isize {

--- a/examples/fwd_midi.rs
+++ b/examples/fwd_midi.rs
@@ -2,9 +2,7 @@
 extern crate vst;
 
 use vst::api;
-use vst::buffer::{AudioBuffer, SendEventBuffer};
-use vst::event::{Event, MidiEvent};
-use vst::plugin::{CanDo, HostCallback, Info, Plugin};
+use vst::prelude::*;
 
 plugin_main!(MyPlugin); // Important!
 

--- a/examples/gain_effect.rs
+++ b/examples/gain_effect.rs
@@ -4,11 +4,9 @@
 extern crate vst;
 extern crate time;
 
-use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
-use vst::util::AtomicFloat;
-
 use std::sync::Arc;
+
+use vst::prelude::*;
 
 /// Simple Gain Effect.
 /// Note that this does not use a proper scale for sound and shouldn't be used in

--- a/examples/ladder_filter.rs
+++ b/examples/ladder_filter.rs
@@ -16,9 +16,7 @@ use std::f32::consts::PI;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
-use vst::util::AtomicFloat;
+use vst::prelude::*;
 
 // this is a 4-pole filter with resonance, which is why there's 4 states and vouts
 #[derive(Clone)]

--- a/examples/sine_synth.rs
+++ b/examples/sine_synth.rs
@@ -3,10 +3,7 @@
 #[macro_use]
 extern crate vst;
 
-use vst::api::{Events, Supported};
-use vst::buffer::AudioBuffer;
-use vst::event::Event;
-use vst::plugin::{CanDo, Category, HostCallback, Info, Plugin};
+use vst::prelude::*;
 
 use std::f64::consts::PI;
 

--- a/examples/transfer_and_smooth.rs
+++ b/examples/transfer_and_smooth.rs
@@ -10,9 +10,7 @@ extern crate vst;
 use std::f32;
 use std::sync::Arc;
 
-use vst::buffer::AudioBuffer;
-use vst::plugin::{Category, HostCallback, Info, Plugin, PluginParameters};
-use vst::util::ParameterTransfer;
+use vst::prelude::*;
 
 const PARAMETER_COUNT: usize = 100;
 const BASE_FREQUENCY: f32 = 5.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ## `Plugin` Trait
 //! All methods in this trait have a default implementation except for the `get_info` method which
-//! must be implemented by the plugin. Any of the default implementations may be overriden for
+//! must be implemented by the plugin. Any of the default implementations may be overridden for
 //! custom functionality; the defaults do nothing on their own.
 //!
 //! ## `PluginParameters` Trait
@@ -152,7 +152,7 @@ pub mod event;
 pub mod host;
 mod interfaces;
 pub mod plugin;
-
+pub mod prelude;
 pub mod util;
 
 use api::consts::VST_MAGIC;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -67,7 +67,7 @@ pub enum OpCode {
     /// [index]: parameter
     /// [ptr]: char buffer, limited to `consts::MAX_PARAM_STR_LEN` (e.g. "db", "ms", etc)
     GetParameterLabel,
-    /// [index]: paramter
+    /// [index]: parameter
     /// [ptr]: char buffer, limited to `consts::MAX_PARAM_STR_LEN` (e.g. "0.5", "ROOM", etc).
     GetParameterDisplay,
     /// [index]: parameter
@@ -738,7 +738,7 @@ pub trait PluginParameters: Sync {
         format!("Param {}", index)
     }
 
-    /// Get the value of paramater at `index`. Should be value between 0.0 and 1.0.
+    /// Get the value of parameter at `index`. Should be value between 0.0 and 1.0.
     fn get_parameter(&self, index: i32) -> f32 {
         0.0
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,12 @@
+//! A collection of commonly used items
+
+#[doc(no_inline)]
+pub use crate::api::{Events, Supported};
+#[doc(no_inline)]
+pub use crate::buffer::{AudioBuffer, SendEventBuffer};
+#[doc(no_inline)]
+pub use crate::event::{Event, MidiEvent};
+#[doc(no_inline)]
+pub use crate::plugin::{CanDo, Category, HostCallback, Info, Plugin, PluginParameters};
+#[doc(no_inline)]
+pub use crate::util::{AtomicFloat, ParameterTransfer};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,12 +1,12 @@
-//! A collection of commonly used items
+//! A collection of commonly used items for implement a Plugin
 
 #[doc(no_inline)]
-pub use crate::api::{Events, Supported};
+pub use api::{Events, Supported};
 #[doc(no_inline)]
-pub use crate::buffer::{AudioBuffer, SendEventBuffer};
+pub use buffer::{AudioBuffer, SendEventBuffer};
 #[doc(no_inline)]
-pub use crate::event::{Event, MidiEvent};
+pub use event::{Event, MidiEvent};
 #[doc(no_inline)]
-pub use crate::plugin::{CanDo, Category, HostCallback, Info, Plugin, PluginParameters};
+pub use plugin::{CanDo, Category, HostCallback, Info, Plugin, PluginParameters};
 #[doc(no_inline)]
-pub use crate::util::{AtomicFloat, ParameterTransfer};
+pub use util::{AtomicFloat, ParameterTransfer};


### PR DESCRIPTION
This PR adds a `prelude.rs` with some commonly used types and traits as a sort of demo of @Boscop's [suggestion](https://github.com/RustAudio/vst-rs/issues/156). I've had a look around this crate and tried writing a couple of VST plugins before looking at this. The selection of items was based on that and the provided examples. That being said, it might be a bit excessive to include certain things, e.g. `Event`. 