### PR TITLE
Return whether or not editor key event was handled

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -250,22 +250,24 @@ pub extern "C" fn dispatch(
         Ok(OpCode::EditorKeyDown) => {
             if let Some(ref mut editor) = get_editor() {
                 if let Ok(key) = Key::try_from(value) {
-                    editor.key_down(KeyCode {
+                    let handled = editor.key_down(KeyCode {
                         character: index as u8 as char,
                         key,
                         modifier: opt.to_bits() as u8,
                     });
+                    return handled.into();
                 }
             }
         }
         Ok(OpCode::EditorKeyUp) => {
             if let Some(ref mut editor) = get_editor() {
                 if let Ok(key) = Key::try_from(value) {
-                    editor.key_up(KeyCode {
+                    let handled = editor.key_up(KeyCode {
                         character: index as u8 as char,
                         key,
                         modifier: opt.to_bits() as u8,
                     });
+                    return handled.into();
                 }
             }
         }


### PR DESCRIPTION
The host needs to know whether or not the plugin editor handles a given key event. Otherwise, the key event is sent to the host, and we don't receive a key up event.