### PR TITLE
Add deprecation notice to README and bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0
+
+### Changed
+
+- Added deprecation notice.
+
 ## 0.3.0
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vst"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
 	"Marko Mijalkovic <marko.mijalkovic97@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 [![Discord Chat][discord-img]][discord-url]
 [![Discourse topics][dc-img]][dc-url]
 
+> **Notice**: `vst-rs` is deprecated.
+>
+> This crate is no longer actively developed or maintained. VST 2 has been [officially discontinued](http://web.archive.org/web/20210727141622/https://www.steinberg.net/en/newsandevents/news/newsdetail/article/vst-2-coming-to-an-end-4727.html) and it is [no longer possible](https://forum.juce.com/t/steinberg-closing-down-vst2-for-good/27722/25) to acquire a license to distribute VST 2 products. It is highly recommended that you make use of other libraries for developing audio plugins and plugin hosts in Rust.
+>
+> If you're looking for a high-level, multi-format framework for developing plugins in Rust, consider using [NIH-plug](https://github.com/robbert-vdh/nih-plug/) or [`baseplug`](https://github.com/wrl/baseplug/). If you're looking for bindings to specific plugin APIs, consider using [`vst3-sys`](https://github.com/RustAudio/vst3-sys/), [`clap-sys`](https://github.com/glowcoil/clap-sys), [`lv2(-sys)`](https://github.com/RustAudio/rust-lv2), or [`auv2-sys`](https://github.com/glowcoil/auv2-sys). If, despite the above warnings, you still have a need to use the VST 2 API from Rust, consider using [`vst2-sys`](https://github.com/RustAudio/vst2-sys) or generating bindings from the original VST 2 SDK using [`bindgen`](https://github.com/rust-lang/rust-bindgen).
+
 `vst-rs` is a library for creating VST2 plugins in the Rust programming language.
 
 This library is a work in progress, and as such it does not yet implement all


### PR DESCRIPTION
Add a deprecation notice to the README (as discussed in #193), bump the crate version so the notice can be published to crates.io, and update the changelog accordingly.