### PR TITLE
Add the deprecated attribute to the Plugin trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ keywords = ["vst", "vst2", "plugin"]
 
 autoexamples = false
 
+[features]
+default = []
+disable_deprecation_warning = []
+
 [dependencies]
 log = "0.4"
 num-traits = "0.2"

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -469,6 +469,10 @@ impl Into<String> for CanDo {
 /// processing thread. For this reason, the plugin API is separated into two
 /// traits: The `Plugin` trait containing setup and processing methods, and
 /// the `PluginParameters` trait containing methods for parameter access.
+#[cfg_attr(
+    not(feature = "disable_deprecation_warning"),
+    deprecated = "This crate has been deprecated. See https://github.com/RustAudio/vst-rs for more information."
+)]
 #[allow(unused_variables)]
 pub trait Plugin: Send {
     /// This method must return an `Info` struct.


### PR DESCRIPTION
So you can't miss it. The `disable_deprecation_warning` feature can be used to disable the warning if the user has a really good reason to still use the `vst` crate, but it's intentionally undocumented.

This would be part of the 0.4.0 update (I saw nothing had actually been tagged yet).